### PR TITLE
Fixed password being stored in plaintext

### DIFF
--- a/src/components/ChatbotContainer.js
+++ b/src/components/ChatbotContainer.js
@@ -6,6 +6,17 @@ import TypingIndicator from "./TypingIndicator";
 import MESSAGES from "./messages";
 import './SantaChatbot.css';
 
+// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
+async function digestMessage(message) {
+  const msgUint8 = new TextEncoder().encode(message); // encode as (utf-8) Uint8Array
+  const hashBuffer = await window.crypto.subtle.digest("SHA-256", msgUint8); // hash the message
+  const hashArray = Array.from(new Uint8Array(hashBuffer)); // convert buffer to byte array
+  const hashHex = hashArray
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join(""); // convert bytes to hex string
+  return hashHex;
+}
+
 const ChatbotContainer = () => {
   const [stage, setStage] = useState(1); // Current stage of the chatbot
   const [, setName] = useState(""); // User's name
@@ -121,9 +132,10 @@ const ChatbotContainer = () => {
     setInputVisible(false); // Step 1: Hide the input text field
 
     // Step 2: "Santa is typing..."
-    addSantaMessage(MESSAGES.checkMessage, () => {
-      // Step 3: Santa checks the password
-      if (guess.trim().toLowerCase() === MESSAGES.correctPassword.toLowerCase()) {
+    addSantaMessage(MESSAGES.checkMessage, async () => {
+      // Step 3: Santa checks the password, but this time he attended a cybersecurity seminar
+      const guessHash = await digestMessage(guess.trim().toLowerCase() + MESSAGES.passwordSalt);
+      if (guessHash === MESSAGES.passwordHash) {
         addSantaMessage(
           MESSAGES.correctPwdMsg,
           () => setGameOver(true) // End the game on a correct guess

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line 
 const MESSAGES_EN = {
-  correctPassword: "Weihnachtsbaum",
+  passwordSalt: "0F1xc9o@&*Jt!#$J3rSgq9",
+  passwordHash: "96056eabb340970fdf7c0439de5b9587a299ce40162c1d940ea454c930472d48",
   initialGreeting: "Hello! What's your name?",
   myName: "My name is ",
   submit: "Submit",
@@ -61,7 +62,8 @@ Leise flüsterte sie ihre Vermutung, und der Elf nickte mit einem breiten Läche
 };
 
 const MESSAGES = {
-  correctPassword: "Weihnachtsbaum",
+  passwordSalt: "0F1xc9o@&*Jt!#$J3rSgq9",
+  passwordHash: "96056eabb340970fdf7c0439de5b9587a299ce40162c1d940ea454c930472d48",
   initialGreeting: "Hallo! Wie heißt du?",
   submit: "Einreichen",
   myName: "Mein Name ist ",


### PR DESCRIPTION
Removed plaintext password from src/components/messages.js, added password salt and hash digest to src/components/messages.js, added SHA-256 hash digest function to src/components/ChatbotContainer.js, changed src/components/ChatbotContainer.js/ChatbotContainer/handlePasswordSubmit to run salted password guess through the newly function and compare the resulting hash digest with the stored hash digest.

This fixes https://github.com/tridhe/llm-jailbreak/issues/1